### PR TITLE
docs(metainfo): Add link to source repo

### DIFF
--- a/data/io.github.tobagin.digger.metainfo.xml.in
+++ b/data/io.github.tobagin.digger.metainfo.xml.in
@@ -51,6 +51,7 @@
   </screenshots>
   
   <url type="homepage">https://github.com/tobagin/Digger</url>
+  <url type="vcs-browser">https://github.com/tobagin/Digger</url>
   <url type="bugtracker">https://github.com/tobagin/Digger/issues</url>
   
   <developer_name>Thiago Fernandes</developer_name>


### PR DESCRIPTION
cf. https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible link to the project’s source repository in the app’s metadata. Stores and software centers that use AppStream will now display a “Source”/“Code” link pointing to the repository, allowing users to quickly access the project’s code page from the app listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->